### PR TITLE
Discard master and slave terminology

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ type StorageOptionsConf struct {
 	Port                  int               `json:"port"`
 	Hosts                 map[string]string `json:"hosts"` // Deprecated: Addrs instead.
 	Addrs                 []string          `json:"addrs"`
-	MasterName            string            `json:"master_name"`
+	MainName            string            `json:"main_name"`
 	Username              string            `json:"username"`
 	Password              string            `json:"password"`
 	Database              int               `json:"database"`
@@ -153,7 +153,7 @@ type WebHookHandlerConf struct {
 	EventTimeout int64             `bson:"event_timeout" json:"event_timeout"`
 }
 
-type SlaveOptionsConfig struct {
+type SubordinateOptionsConfig struct {
 	UseRPC                          bool    `json:"use_rpc"`
 	UseSSL                          bool    `json:"use_ssl"`
 	SSLInsecureSkipVerify           bool    `json:"ssl_insecure_skip_verify"`
@@ -349,8 +349,8 @@ type Config struct {
 	Storage                  StorageOptionsConf     `json:"storage"`
 	DisableDashboardZeroConf bool                   `json:"disable_dashboard_zeroconf"`
 
-	// Slave Configurations
-	SlaveOptions   SlaveOptionsConfig `json:"slave_options"`
+	// Subordinate Configurations
+	SubordinateOptions   SubordinateOptionsConfig `json:"subordinate_options"`
 	ManagementNode bool               `json:"management_node"`
 	AuthOverride   AuthOverrideConf   `json:"auth_override"`
 
@@ -375,10 +375,10 @@ type Config struct {
 	CloseIdleConnections bool  `json:"close_idle_connections"`
 	CloseConnections     bool  `json:"close_connections"`
 	EnableCustomDomains  bool  `json:"enable_custom_domains"`
-	// If AllowMasterKeys is set to true, session objects (key definitions) that do not have explicit access rights set
+	// If AllowMainKeys is set to true, session objects (key definitions) that do not have explicit access rights set
 	// will be allowed by Tyk. This means that keys that are created have access to ALL APIs, which in many cases is
 	// unwanted behaviour unless you are sure about what you are doing.
-	AllowMasterKeys bool `json:"allow_master_keys"`
+	AllowMainKeys bool `json:"allow_main_keys"`
 
 	// Gateway-Service Configuration
 	ServiceDiscovery              ServiceDiscoveryConf `json:"service_discovery"`

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -266,9 +266,9 @@ func doAddOrUpdate(keyName string, newSession *user.SessionState, dontReset bool
 		}
 	} else {
 		// nothing defined, add key to ALL
-		if !config.Global().AllowMasterKeys {
-			log.Error("Master keys disallowed in configuration, key not added.")
-			return errors.New("Master keys not allowed")
+		if !config.Global().AllowMainKeys {
+			log.Error("Main keys disallowed in configuration, key not added.")
+			return errors.New("Main keys not allowed")
 		}
 		log.Warning("No API Access Rights set, adding key to ALL.")
 		apisMu.RLock()
@@ -595,7 +595,7 @@ func handleAddKey(keyName, hashedName, sessionString, apiID string) {
 		"prefix": "RPC",
 		"key":    obfuscateKey(keyName),
 		"status": "ok",
-	}).Info("Updated hashed key in slave storage.")
+	}).Info("Updated hashed key in subordinate storage.")
 }
 
 func handleDeleteKey(keyName, apiID string, resetQuota bool) (interface{}, int) {
@@ -1289,7 +1289,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		if config.Global().AllowMasterKeys {
+		if config.Global().AllowMainKeys {
 			// nothing defined, add key to ALL
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
@@ -1321,14 +1321,14 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
 				"status":      "error",
-				"err":         "master keys disabled",
+				"err":         "main keys disabled",
 				"org_id":      newSession.OrgID,
 				"api_id":      "--",
 				"user_id":     "system",
 				"user_ip":     requestIPHops(r),
 				"path":        "--",
 				"server_name": "system",
-			}).Error("Master keys disallowed in configuration, key not added.")
+			}).Error("Main keys disallowed in configuration, key not added.")
 
 			doJSONWrite(w, http.StatusBadRequest, apiError("Failed to create key, keys must have at least one Access Rights record set."))
 			return

--- a/gateway/api_test.go
+++ b/gateway/api_test.go
@@ -132,8 +132,8 @@ func TestKeyHandler(t *testing.T) {
 	})
 
 	// Access right not specified
-	masterKey := CreateStandardSession()
-	masterKeyJSON, _ := json.Marshal(masterKey)
+	mainKey := CreateStandardSession()
+	mainKeyJSON, _ := json.Marshal(mainKey)
 
 	// with access
 	withAccess := CreateStandardSession()
@@ -174,8 +174,8 @@ func TestKeyHandler(t *testing.T) {
 
 	t.Run("Create key", func(t *testing.T) {
 		ts.Run(t, []test.TestCase{
-			// Master keys should be disabled by default
-			{Method: "POST", Path: "/tyk/keys/create", Data: string(masterKeyJSON), AdminAuth: true, Code: 400, BodyMatch: "Failed to create key, keys must have at least one Access Rights record set."},
+			// Main keys should be disabled by default
+			{Method: "POST", Path: "/tyk/keys/create", Data: string(mainKeyJSON), AdminAuth: true, Code: 400, BodyMatch: "Failed to create key, keys must have at least one Access Rights record set."},
 			{Method: "POST", Path: "/tyk/keys/create", Data: string(withAccessJSON), AdminAuth: true, Code: 200},
 		}...)
 	})

--- a/gateway/host_checker_manager.go
+++ b/gateway/host_checker_manager.go
@@ -128,7 +128,7 @@ func (hc *HostCheckerManager) checkPollerLoop(ctx context.Context) {
 		} else {
 			log.WithFields(logrus.Fields{
 				"prefix": "host-check-mgr",
-			}).Debug("New master found, no tests running")
+			}).Debug("New main found, no tests running")
 			if hc.pollerStarted {
 				hc.StopPoller()
 				hc.pollerStarted = false
@@ -156,7 +156,7 @@ func (hc *HostCheckerManager) AmIPolling() bool {
 	if activeInstance == hc.Id {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
-		}).Debug("Primary instance set, I am master")
+		}).Debug("Primary instance set, I am main")
 		hc.store.SetKey(PollerCacheKey, hc.Id, 15) // Reset TTL
 		return true
 	}

--- a/gateway/redis_signal_handle_config.go
+++ b/gateway/redis_signal_handle_config.go
@@ -118,7 +118,7 @@ func sanitizeConfig(mc map[string]interface{}) map[string]interface{} {
 		"secret",
 		"node_secret",
 		"storage",
-		"slave_options",
+		"subordinate_options",
 		"auth_override",
 	}
 	for _, field_name := range sanitzeFields {

--- a/gateway/rpc_storage_handler.go
+++ b/gateway/rpc_storage_handler.go
@@ -99,17 +99,17 @@ var RPCGlobalCache = cache.New(30*time.Second, 15*time.Second)
 
 // Connect will establish a connection to the RPC
 func (r *RPCStorageHandler) Connect() bool {
-	slaveOptions := config.Global().SlaveOptions
+	subordinateOptions := config.Global().SubordinateOptions
 	rpcConfig := rpc.Config{
-		UseSSL:                slaveOptions.UseSSL,
-		SSLInsecureSkipVerify: slaveOptions.SSLInsecureSkipVerify,
-		ConnectionString:      slaveOptions.ConnectionString,
-		RPCKey:                slaveOptions.RPCKey,
-		APIKey:                slaveOptions.APIKey,
-		GroupID:               slaveOptions.GroupID,
-		CallTimeout:           slaveOptions.CallTimeout,
-		PingTimeout:           slaveOptions.PingTimeout,
-		RPCPoolSize:           slaveOptions.RPCPoolSize,
+		UseSSL:                subordinateOptions.UseSSL,
+		SSLInsecureSkipVerify: subordinateOptions.SSLInsecureSkipVerify,
+		ConnectionString:      subordinateOptions.ConnectionString,
+		RPCKey:                subordinateOptions.RPCKey,
+		APIKey:                subordinateOptions.APIKey,
+		GroupID:               subordinateOptions.GroupID,
+		CallTimeout:           subordinateOptions.CallTimeout,
+		PingTimeout:           subordinateOptions.PingTimeout,
+		RPCPoolSize:           subordinateOptions.RPCPoolSize,
 	}
 
 	return rpc.Connect(
@@ -166,7 +166,7 @@ func (r *RPCStorageHandler) GetKey(keyName string) (string, error) {
 
 func (r *RPCStorageHandler) GetRawKey(keyName string) (string, error) {
 	// Check the cache first
-	if config.Global().SlaveOptions.EnableRPCCache {
+	if config.Global().SubordinateOptions.EnableRPCCache {
 		log.Debug("Using cache for: ", keyName)
 		cachedVal, found := RPCGlobalCache.Get(keyName)
 		log.Debug("--> Found? ", found)
@@ -193,7 +193,7 @@ func (r *RPCStorageHandler) GetRawKey(keyName string) (string, error) {
 		log.Debug("Error trying to get value:", err)
 		return "", storage.ErrKeyNotFound
 	}
-	if config.Global().SlaveOptions.EnableRPCCache {
+	if config.Global().SubordinateOptions.EnableRPCCache {
 		// Cache key
 		RPCGlobalCache.Set(keyName, value, cache.DefaultExpiration)
 	}
@@ -700,14 +700,14 @@ func (r *RPCStorageHandler) CheckForReload(orgId string) {
 }
 
 func (r *RPCStorageHandler) StartRPCLoopCheck(orgId string) {
-	if config.Global().SlaveOptions.DisableKeySpaceSync {
+	if config.Global().SubordinateOptions.DisableKeySpaceSync {
 		return
 	}
 
 	log.Info("[RPC] Starting keyspace poller")
 
 	for {
-		seconds := config.Global().SlaveOptions.KeySpaceSyncInterval
+		seconds := config.Global().SubordinateOptions.KeySpaceSyncInterval
 		r.CheckForKeyspaceChanges(orgId)
 		time.Sleep(time.Duration(seconds) * time.Second)
 	}
@@ -749,7 +749,7 @@ func (r *RPCStorageHandler) CheckForKeyspaceChanges(orgId string) {
 	var req interface{}
 
 	reqData := map[string]string{}
-	if groupID := config.Global().SlaveOptions.GroupID; groupID == "" {
+	if groupID := config.Global().SubordinateOptions.GroupID; groupID == "" {
 		funcName = "GetKeySpaceUpdate"
 		req = orgId
 		reqData["orgId"] = orgId
@@ -795,7 +795,7 @@ func getSessionAndCreate(keyName string, r *RPCStorageHandler) {
 	newKeyName := "apikey-" + storage.HashStr(keyName)
 	sessionString, err := r.GetRawKey(keyName)
 	if err != nil {
-		log.Error("Key not found in master - skipping")
+		log.Error("Key not found in main - skipping")
 	} else {
 		handleAddKey(keyName, newKeyName[7:], sessionString, "-1")
 	}

--- a/gateway/service_discovery_test.go
+++ b/gateway/service_discovery_test.go
@@ -152,7 +152,7 @@ const mesosphere = `{
 		"startedAt": "2016-03-15T14:37:55.941Z",
 		"stagedAt": "2016-03-15T14:37:52.792Z",
 		"version": "2016-03-15T14:37:52.726Z",
-		"slaveId": "d70867df-fdb2-4889-abeb-0829c742fded-S2",
+		"subordinateId": "d70867df-fdb2-4889-abeb-0829c742fded-S2",
 		"appId": "/httpbin"
 	}]
 }`

--- a/vendor/github.com/Masterminds/sprig/crypto.go
+++ b/vendor/github.com/Masterminds/sprig/crypto.go
@@ -51,7 +51,7 @@ func uuidv4() string {
 	return fmt.Sprintf("%s", uuid.New())
 }
 
-var master_password_seed = "com.lyndir.masterpassword"
+var main_password_seed = "com.lyndir.mainpassword"
 
 var password_type_templates = map[string][][]byte{
 	"maximum": {[]byte("anoxxxxxxxxxxxxxxxxx"), []byte("axxxxxxxxxxxxxxxxxno")},
@@ -85,7 +85,7 @@ func derivePassword(counter uint32, password_type, password, user, site string) 
 	}
 
 	var buffer bytes.Buffer
-	buffer.WriteString(master_password_seed)
+	buffer.WriteString(main_password_seed)
 	binary.Write(&buffer, binary.BigEndian, uint32(len(user)))
 	buffer.WriteString(user)
 
@@ -95,7 +95,7 @@ func derivePassword(counter uint32, password_type, password, user, site string) 
 		return fmt.Sprintf("failed to derive password: %s", err)
 	}
 
-	buffer.Truncate(len(master_password_seed))
+	buffer.Truncate(len(main_password_seed))
 	binary.Write(&buffer, binary.BigEndian, uint32(len(site)))
 	buffer.WriteString(site)
 	binary.Write(&buffer, binary.BigEndian, counter)

--- a/vendor/github.com/Masterminds/sprig/doc.go
+++ b/vendor/github.com/Masterminds/sprig/doc.go
@@ -14,6 +14,6 @@ Note that you should add the function map before you parse any template files.
 	appear in the standard library. This is to make it easier to pipe
 	arguments into functions.
 
-See http://masterminds.github.io/sprig/ for more detailed documentation on each of the available functions.
+See http://mainminds.github.io/sprig/ for more detailed documentation on each of the available functions.
 */
 package sprig

--- a/vendor/github.com/go-redis/redis/cluster_commands.go
+++ b/vendor/github.com/go-redis/redis/cluster_commands.go
@@ -5,8 +5,8 @@ import "sync/atomic"
 func (c *ClusterClient) DBSize() *IntCmd {
 	cmd := NewIntCmd("dbsize")
 	var size int64
-	err := c.ForEachMaster(func(master *Client) error {
-		n, err := master.DBSize().Result()
+	err := c.ForEachMain(func(main *Client) error {
+		n, err := main.DBSize().Result()
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/go-redis/redis/commands.go
+++ b/vendor/github.com/go-redis/redis/commands.go
@@ -248,7 +248,7 @@ type Cmdable interface {
 	Shutdown() *StatusCmd
 	ShutdownSave() *StatusCmd
 	ShutdownNoSave() *StatusCmd
-	SlaveOf(host, port string) *StatusCmd
+	SubordinateOf(host, port string) *StatusCmd
 	Time() *TimeCmd
 	Eval(script string, keys []string, args ...interface{}) *Cmd
 	EvalSha(sha1 string, keys []string, args ...interface{}) *Cmd
@@ -276,7 +276,7 @@ type Cmdable interface {
 	ClusterDelSlots(slots ...int) *StatusCmd
 	ClusterDelSlotsRange(min, max int) *StatusCmd
 	ClusterSaveConfig() *StatusCmd
-	ClusterSlaves(nodeID string) *StringSliceCmd
+	ClusterSubordinates(nodeID string) *StringSliceCmd
 	ClusterFailover() *StatusCmd
 	ClusterAddSlots(slots ...int) *StatusCmd
 	ClusterAddSlotsRange(min, max int) *StatusCmd
@@ -344,8 +344,8 @@ func (c *cmdable) Ping() *StatusCmd {
 	return cmd
 }
 
-func (c *cmdable) Wait(numSlaves int, timeout time.Duration) *IntCmd {
-	cmd := NewIntCmd("wait", numSlaves, int(timeout/time.Millisecond))
+func (c *cmdable) Wait(numSubordinates int, timeout time.Duration) *IntCmd {
+	cmd := NewIntCmd("wait", numSubordinates, int(timeout/time.Millisecond))
 	c.process(cmd)
 	return cmd
 }
@@ -2223,8 +2223,8 @@ func (c *cmdable) ShutdownNoSave() *StatusCmd {
 	return c.shutdown("nosave")
 }
 
-func (c *cmdable) SlaveOf(host, port string) *StatusCmd {
-	cmd := NewStatusCmd("slaveof", host, port)
+func (c *cmdable) SubordinateOf(host, port string) *StatusCmd {
+	cmd := NewStatusCmd("subordinateof", host, port)
 	c.process(cmd)
 	return cmd
 }
@@ -2449,8 +2449,8 @@ func (c *cmdable) ClusterSaveConfig() *StatusCmd {
 	return cmd
 }
 
-func (c *cmdable) ClusterSlaves(nodeID string) *StringSliceCmd {
-	cmd := NewStringSliceCmd("cluster", "slaves", nodeID)
+func (c *cmdable) ClusterSubordinates(nodeID string) *StringSliceCmd {
+	cmd := NewStringSliceCmd("cluster", "subordinates", nodeID)
 	c.process(cmd)
 	return cmd
 }

--- a/vendor/github.com/go-redis/redis/options.go
+++ b/vendor/github.com/go-redis/redis/options.go
@@ -90,7 +90,7 @@ type Options struct {
 	// if IdleTimeout is set.
 	IdleCheckFrequency time.Duration
 
-	// Enables read only queries on slave nodes.
+	// Enables read only queries on subordinate nodes.
 	readOnly bool
 
 	// TLS Config to use. When set TLS will be negotiated.

--- a/vendor/github.com/go-redis/redis/universal.go
+++ b/vendor/github.com/go-redis/redis/universal.go
@@ -41,9 +41,9 @@ type UniversalOptions struct {
 	RouteByLatency bool
 	RouteRandomly  bool
 
-	// The sentinel master name.
+	// The sentinel main name.
 	// Only failover clients.
-	MasterName string
+	MainName string
 }
 
 func (o *UniversalOptions) cluster() *ClusterOptions {
@@ -87,7 +87,7 @@ func (o *UniversalOptions) failover() *FailoverOptions {
 
 	return &FailoverOptions{
 		SentinelAddrs: o.Addrs,
-		MasterName:    o.MasterName,
+		MainName:    o.MainName,
 		OnConnect:     o.OnConnect,
 
 		DB:       o.DB,
@@ -167,11 +167,11 @@ var _ UniversalClient = (*ClusterClient)(nil)
 // NewUniversalClient returns a new multi client. The type of client returned depends
 // on the following three conditions:
 //
-// 1. if a MasterName is passed a sentinel-backed FailoverClient will be returned
+// 1. if a MainName is passed a sentinel-backed FailoverClient will be returned
 // 2. if the number of Addrs is two or more, a ClusterClient will be returned
 // 3. otherwise, a single-node redis Client will be returned.
 func NewUniversalClient(opts *UniversalOptions) UniversalClient {
-	if opts.MasterName != "" {
+	if opts.MainName != "" {
 		return NewFailoverClient(opts.failover())
 	} else if len(opts.Addrs) > 1 {
 		return NewClusterClient(opts.cluster())

--- a/vendor/github.com/golang/protobuf/proto/discard.go
+++ b/vendor/github.com/golang/protobuf/proto/discard.go
@@ -60,7 +60,7 @@ func DiscardUnknown(m Message) {
 		return
 	}
 	// TODO: Dynamically populate a InternalMessageInfo for legacy messages,
-	// but the master branch has no implementation for InternalMessageInfo,
+	// but the main branch has no implementation for InternalMessageInfo,
 	// so it would be more work to replicate that approach.
 	discardLegacy(m)
 }

--- a/vendor/github.com/hashicorp/consul/api/agent.go
+++ b/vendor/github.com/hashicorp/consul/api/agent.go
@@ -920,12 +920,12 @@ func (a *Agent) UpdateACLAgentToken(token string, q *WriteOptions) (*WriteMeta, 
 	return a.updateToken("acl_agent_token", token, q)
 }
 
-// UpdateACLAgentMasterToken updates the agent's "acl_agent_master_token". See
+// UpdateACLAgentMainToken updates the agent's "acl_agent_main_token". See
 // updateToken for more details.
 //
-// DEPRECATED (ACL-Legacy-Compat) - Prefer UpdateAgentMasterACLToken for v1.4.3 and above
-func (a *Agent) UpdateACLAgentMasterToken(token string, q *WriteOptions) (*WriteMeta, error) {
-	return a.updateToken("acl_agent_master_token", token, q)
+// DEPRECATED (ACL-Legacy-Compat) - Prefer UpdateAgentMainACLToken for v1.4.3 and above
+func (a *Agent) UpdateACLAgentMainToken(token string, q *WriteOptions) (*WriteMeta, error) {
+	return a.updateToken("acl_agent_main_token", token, q)
 }
 
 // UpdateACLReplicationToken updates the agent's "acl_replication_token". See
@@ -948,10 +948,10 @@ func (a *Agent) UpdateAgentACLToken(token string, q *WriteOptions) (*WriteMeta, 
 	return a.updateTokenFallback("agent", "acl_agent_token", token, q)
 }
 
-// UpdateAgentMasterACLToken updates the agent's "agent_master" token. See updateToken
+// UpdateAgentMainACLToken updates the agent's "agent_main" token. See updateToken
 // for more details
-func (a *Agent) UpdateAgentMasterACLToken(token string, q *WriteOptions) (*WriteMeta, error) {
-	return a.updateTokenFallback("agent_master", "acl_agent_master_token", token, q)
+func (a *Agent) UpdateAgentMainACLToken(token string, q *WriteOptions) (*WriteMeta, error) {
+	return a.updateTokenFallback("agent_main", "acl_agent_main_token", token, q)
 }
 
 // UpdateReplicationACLToken updates the agent's "replication" token. See updateToken

--- a/vendor/github.com/mattn/go-isatty/isatty_windows.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_windows.go
@@ -38,7 +38,7 @@ func IsTerminal(fd uintptr) bool {
 
 // Check pipe name is used for cygwin/msys2 pty.
 // Cygwin/MSYS2 PTY has a name like:
-//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
+//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-main
 func isCygwinPipeName(name string) bool {
 	token := strings.Split(name, "-")
 	if len(token) < 5 {
@@ -61,7 +61,7 @@ func isCygwinPipeName(name string) bool {
 		return false
 	}
 
-	if token[4] != "master" {
+	if token[4] != "main" {
 		return false
 	}
 

--- a/vendor/github.com/miekg/dns/xfr.go
+++ b/vendor/github.com/miekg/dns/xfr.go
@@ -29,10 +29,10 @@ type Transfer struct {
 // in the Transfer.Conn:
 //
 //	d := net.Dialer{LocalAddr: transfer_source}
-//	con, err := d.Dial("tcp", master)
+//	con, err := d.Dial("tcp", main)
 //	dnscon := &dns.Conn{Conn:con}
 //	transfer = &dns.Transfer{Conn: dnscon}
-//	channel, err := transfer.In(message, master)
+//	channel, err := transfer.In(message, main)
 //
 func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
 	timeout := dnsTimeout

--- a/vendor/golang.org/x/net/publicsuffix/table.go
+++ b/vendor/golang.org/x/net/publicsuffix/table.go
@@ -440,7 +440,7 @@ const text = "9guacuiababia-goracleaningroks-theatree164-baltimore-og-romsdali" 
 	"ahamaxn--osyro-wuaxn--otu796dxn--p1acfermobilyxn--p1ais-very-goo" +
 	"dyearxn--pbt977cnpyatigorskodjeffersonxn--pgbs0dhlxn--porsgu-sta" +
 	"26ferraraxn--pssu33lxn--pssy2uxn--q9jyb4cnsantoandreamhostersanu" +
-	"kis-a-cubicle-slavellinodearthachiojiyaitakanabeautysvardoesntex" +
+	"kis-a-cubicle-subordinatellinodearthachiojiyaitakanabeautysvardoesntex" +
 	"isteingeekashibatakasugais-a-democratozsdeltaiwanairforcebetsuik" +
 	"idsmynasushiobarackmazerbaijan-mayendoftheinternetflixilovecolle" +
 	"gefantasyleaguernseyxn--qcka1pmckinseyxn--qqqt11mishimatsumaebas" +

--- a/vendor/golang.org/x/sys/unix/mksysnum.go
+++ b/vendor/golang.org/x/sys/unix/mksysnum.go
@@ -5,8 +5,8 @@
 // +build ignore
 
 // Generate system call table for DragonFly, NetBSD,
-// FreeBSD, OpenBSD or Darwin from master list
-// (for example, /usr/src/sys/kern/syscalls.master or
+// FreeBSD, OpenBSD or Darwin from main list
+// (for example, /usr/src/sys/kern/syscalls.main or
 // sys/syscall.h).
 package main
 
@@ -107,7 +107,7 @@ func main() {
 	file := strings.TrimSpace(os.Args[1])
 	var syscalls io.Reader
 	if strings.HasPrefix(file, "https://") || strings.HasPrefix(file, "http://") {
-		// Download syscalls.master file
+		// Download syscalls.main file
 		syscalls = fetchFile(file)
 	} else {
 		syscalls = readFile(file)

--- a/vendor/gopkg.in/Masterminds/sprig.v2/crypto.go
+++ b/vendor/gopkg.in/Masterminds/sprig.v2/crypto.go
@@ -51,7 +51,7 @@ func uuidv4() string {
 	return fmt.Sprintf("%s", uuid.New())
 }
 
-var master_password_seed = "com.lyndir.masterpassword"
+var main_password_seed = "com.lyndir.mainpassword"
 
 var password_type_templates = map[string][][]byte{
 	"maximum": {[]byte("anoxxxxxxxxxxxxxxxxx"), []byte("axxxxxxxxxxxxxxxxxno")},
@@ -85,7 +85,7 @@ func derivePassword(counter uint32, password_type, password, user, site string) 
 	}
 
 	var buffer bytes.Buffer
-	buffer.WriteString(master_password_seed)
+	buffer.WriteString(main_password_seed)
 	binary.Write(&buffer, binary.BigEndian, uint32(len(user)))
 	buffer.WriteString(user)
 
@@ -95,7 +95,7 @@ func derivePassword(counter uint32, password_type, password, user, site string) 
 		return fmt.Sprintf("failed to derive password: %s", err)
 	}
 
-	buffer.Truncate(len(master_password_seed))
+	buffer.Truncate(len(main_password_seed))
 	binary.Write(&buffer, binary.BigEndian, uint32(len(site)))
 	buffer.WriteString(site)
 	binary.Write(&buffer, binary.BigEndian, counter)

--- a/vendor/gopkg.in/Masterminds/sprig.v2/doc.go
+++ b/vendor/gopkg.in/Masterminds/sprig.v2/doc.go
@@ -14,6 +14,6 @@ Note that you should add the function map before you parse any template files.
 	appear in the standard library. This is to make it easier to pipe
 	arguments into functions.
 
-See http://masterminds.github.io/sprig/ for more detailed documentation on each of the available functions.
+See http://mainminds.github.io/sprig/ for more detailed documentation on each of the available functions.
 */
 package sprig


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.